### PR TITLE
[Tests] Remove timing constraints for count rules

### DIFF
--- a/tests/VObject/Recur/FastForwardToEndTest.php
+++ b/tests/VObject/Recur/FastForwardToEndTest.php
@@ -10,16 +10,14 @@ class FastForwardToEndTest extends TestCase
 {
     const FF_TIMEOUT = 1000000; // in usec
 
-    private function fastForwardToEnd(RRuleIterator $ruleIterator)
+    private function fastForwardToEnd(RRuleIterator $ruleIterator, $enfoceTiming = true)
     {
         $ru = getrusage();
         $startTime = $ru['ru_utime.tv_sec'] * 1000000 + $ru['ru_utime.tv_usec'];
         $ruleIterator->fastForwardToEnd();
         $ru = getrusage();
         $endTime = $ru['ru_utime.tv_sec'] * 1000000 + $ru['ru_utime.tv_usec'];
-        $this->assertLessThan(self::FF_TIMEOUT, $endTime - $startTime);
-
-        echo "taken " . ($endTime - $startTime) / 1000 . "ms\n";
+        $enfoceTiming && $this->assertLessThan(self::FF_TIMEOUT, $endTime - $startTime);
         $this->assertTrue($ruleIterator->valid());
         $this->assertNotNull($ruleIterator->current());
     }
@@ -38,7 +36,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new DateTime('1970-10-23 00:00:00', new DateTimeZone('zulu'));
         $rrule = new RRuleIterator('FREQ=YEARLY;COUNT=7777', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime())
             ->setTimezone(new DateTimeZone('zulu'))
@@ -68,7 +67,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 00:00:00', new \DateTimeZone('zulu'));
         $rrule = new RRuleIterator('FREQ=YEARLY;BYYEARDAY=1,20,300;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime())
             ->setTimezone(new DateTimeZone('zulu'))
@@ -100,7 +100,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 00:00:00', new \DateTimeZone('zulu'));
         $rrule = new RRuleIterator('FREQ=YEARLY;BYWEEKNO=1,20;COUNT=100', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime())
             ->setTimezone(new DateTimeZone('zulu'))
@@ -131,7 +132,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 12:34:56', new \DateTimeZone('zulu'));
         $rrule = new RRuleIterator('FREQ=YEARLY;INTERVAL=2;BYMONTH=1;BYDAY=SU;BYHOUR=8,9;BYMINUTE=30;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone('zulu')))
             ->setDate(4226, 1, 1)
@@ -159,7 +161,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 22:42:31', new \DateTimeZone('zulu'));
         $rrule = new RRuleIterator('FREQ=MONTHLY;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone('zulu')))
             ->setDate(2804, 1, 23)
@@ -182,12 +185,14 @@ class FastForwardToEndTest extends TestCase
         $this->assertEquals($expected, $rrule->current()->getTimestamp());
     }
 
+    // FIXME fails in <=PHP 7.1
     public function testFastForwardToEndCountMonthly31thDay()
     {
         $startDate = new \DateTime('1970-01-31 00:00:00', new \DateTimeZone('America/New_York'));
         $rrule = new RRuleIterator('FREQ=MONTHLY;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone('America/New_York')))
             ->setDate(3398, 10, 31)
@@ -214,7 +219,8 @@ class FastForwardToEndTest extends TestCase
         // every 2 months on the 1st Monday, 2nd Tuesday, 3rd Wednesday and 4th Thursday
         $rrule = new RRuleIterator('FREQ=MONTHLY;INTERVAL=2;BYDAY=1MO,2TU,3WE,4TH;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone('America/New_York')))
             ->setDate(2386, 9, 17)
@@ -242,7 +248,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 00:00:00', new \DateTimeZone($timezone));
         $rrule = new RRuleIterator('FREQ=DAILY;COUNT=100000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone($timezone)))
             ->setDate(2244, 8, 6)
@@ -271,7 +278,8 @@ class FastForwardToEndTest extends TestCase
         // every 10 days at 16, 17 and 18
         $rrule = new RRuleIterator('FREQ=DAILY;BYHOUR=16,17,18;INTERVAL=10;COUNT=10000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone($timezone)))
             ->setDate(2062, 1, 13)
@@ -302,7 +310,8 @@ class FastForwardToEndTest extends TestCase
         $startDate = new \DateTime('1970-10-23 00:12:34', new \DateTimeZone($timezone));
         $rrule = new RRuleIterator('FREQ=HOURLY;COUNT=100000', $startDate);
 
-        $this->fastForwardToEnd($rrule);
+        // We do not enforce the timing in case of a count rule as we cannot optimize it
+        $this->fastForwardToEnd($rrule, false);
 
         $expected = (new DateTime('midnight', new DateTimeZone($timezone)))
             ->setDate(1982, 3, 21)


### PR DESCRIPTION
Remove timing constraints for count rules as we cannot optimize them
Remove print from tests