### PR TITLE
FREQ is mandatory in the RRule

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -962,6 +962,11 @@ class RRuleIterator implements Iterator
                     throw new InvalidDataException('Not supported: '.strtoupper($key));
             }
         }
+
+        // FREQ is mandatory
+        if (!isset($this->frequency)) {
+            throw new InvalidDataException('Unknown value for FREQ');
+        }
     }
 
     /**

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -9,6 +9,18 @@ use PHPUnit\Framework\TestCase;
 
 class RRuleIteratorTest extends TestCase
 {
+    /**
+     * @expectedException \Sabre\VObject\InvalidDataException
+     */
+    public function testInvalidMissingFreq()
+    {
+        $this->parse(
+            'COUNT=6;BYMONTHDAY=24;BYMONTH=1',
+            '2011-04-07 00:00:00',
+            []
+        );
+    }
+
     public function testHourly()
     {
         $this->parse(

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -6,14 +6,13 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Sabre\VObject\InvalidDataException;
 
 class RRuleIteratorTest extends TestCase
 {
-    /**
-     * @expectedException \Sabre\VObject\InvalidDataException
-     */
     public function testInvalidMissingFreq()
     {
+        $this->expectException(InvalidDataException::class);
         $this->parse(
             'COUNT=6;BYMONTHDAY=24;BYMONTH=1',
             '2011-04-07 00:00:00',


### PR DESCRIPTION
The Freq property is mandatory in a recurrence rule.

From RFC

      The FREQ rule part identifies the type of recurrence rule.  This
      rule part MUST be specified in the recurrence rule.

https://tools.ietf.org/html/rfc5545#section-3.3.10

Fixes CALENDAR-643