### PR TITLE
Validate BYMONTHDAY

### DIFF
--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -921,6 +921,15 @@ class RRuleIterator implements Iterator
 
                 case 'BYMONTHDAY':
                     $this->byMonthDay = (array) $value;
+                    foreach ($this->byMonthDay as $byMonthDay) {
+                        if (!is_numeric($byMonthDay)) {
+                            throw new InvalidDataException('BYMONTHDAY in RRULE has a not numeric value(s)!');
+                        }
+                        $byMonthDay = (int) $byMonthDay;
+                        if ($byMonthDay < -31 || 0 === $byMonthDay || $byMonthDay > 31) {
+                            throw new InvalidDataException('BYMONTHDAY in RRULE must have value(s) from 1 to 31, or -31 to -1!');
+                        }
+                    }
                     break;
 
                 case 'BYYEARDAY':

--- a/tests/VObject/Recur/RRuleIteratorTest.php
+++ b/tests/VObject/Recur/RRuleIteratorTest.php
@@ -10,16 +10,6 @@ use Sabre\VObject\InvalidDataException;
 
 class RRuleIteratorTest extends TestCase
 {
-    public function testInvalidMissingFreq()
-    {
-        $this->expectException(InvalidDataException::class);
-        $this->parse(
-            'COUNT=6;BYMONTHDAY=24;BYMONTH=1',
-            '2011-04-07 00:00:00',
-            []
-        );
-    }
-
     public function testHourly()
     {
         $this->parse(
@@ -313,6 +303,16 @@ class RRuleIteratorTest extends TestCase
                 '2012-04-01 00:00:00',
                 '2012-04-24 00:00:00',
             ]
+        );
+    }
+
+    public function testInvalidByMonthDay()
+    {
+        $this->expectException(InvalidDataException::class);
+        $this->parse(
+            'FREQ=MONTHLY;COUNT=6;BYMONTHDAY=1,5,10,42',
+            '2011-04-07 00:00:00',
+            []
         );
     }
 
@@ -891,6 +891,16 @@ class RRuleIteratorTest extends TestCase
         $this->parse(
             'FREQ=SMONTHLY;INTERVAL=3;UNTIL=20111025T000000Z',
             '2011-10-07',
+            []
+        );
+    }
+
+    public function testInvalidMissingFreq()
+    {
+        $this->expectException(InvalidDataException::class);
+        $this->parse(
+            'COUNT=6;BYMONTHDAY=24;BYMONTH=1',
+            '2011-04-07 00:00:00',
             []
         );
     }


### PR DESCRIPTION
From the RFC, the ByMonthDay parameter can only take values in `[1,31] u [-31,-1]`

      The BYMONTHDAY rule part specifies a COMMA-separated list of days
      of the month.  Valid values are 1 to 31 or -31 to -1.

https://tools.ietf.org/html/rfc5545#section-3.3.10