### PR TITLE
Add Europe localized timezone in FR

### DIFF
--- a/lib/timezonedata/exchangezones.php
+++ b/lib/timezonedata/exchangezones.php
@@ -91,4 +91,7 @@ return [
     'Hawaii' => 'Pacific/Honolulu',
     'Midway Island, Samoa' => 'Pacific/Midway',
     'Eniwetok, Kwajalein, Dateline Time' => 'Pacific/Kwajalein',
+
+    // Localized timezones
+    'Amsterdam, Berlin, Berne, Rome, Stockholm, Vienne' => 'Europe/Berlin',
 ];


### PR DESCRIPTION
Exchange 2010 might localize timezone names depending on the user's settings. Adding the CET/CEST timezone localized in french