### PR TITLE
Deprecate Enderbury timezone

### DIFF
--- a/lib/timezonedata/extrazones.php
+++ b/lib/timezonedata/extrazones.php
@@ -133,7 +133,7 @@ return [
     'Paraguay' => 'America/Asuncion',
     'Peru' => 'America/Lima',
     'Philippines' => 'Asia/Manila',
-    'Phoenix Islands' => 'Pacific/Enderbury',
+    'Phoenix Islands' => 'Pacific/Fakaofo',
     'Pierre Miquelon' => 'America/Miquelon',
     'Pitcairn' => 'Pacific/Pitcairn',
     'Pyongyang' => 'Asia/Pyongyang',

--- a/lib/timezonedata/windowszones.php
+++ b/lib/timezonedata/windowszones.php
@@ -232,7 +232,7 @@ return [
   'coordinated universal time+12' => 'Pacific/Tarawa',
   'petropavlovsk-kamchatsky - old' => 'Asia/Anadyr',
   'chatham islands' => 'Pacific/Chatham',
-  'coordinated universal time+13' => 'Pacific/Enderbury',
+  'coordinated universal time+13' => 'Pacific/Fakaofo',
   "nuku'alofa" => 'Pacific/Tongatapu',
   'kiritimati island' => 'Pacific/Kiritimati',
   'helsinki, kyiv, riga, sofia, tallinn, vilnius' => 'Europe/Helsinki',

--- a/tests/VObject/microsoft-timezones-confluence.csv
+++ b/tests/VObject/microsoft-timezones-confluence.csv
@@ -338,7 +338,7 @@ paraguay standard time,America/Asuncion,America/Asuncion,FALSE
 "perth, western australia",Australia/Perth,Australia/Perth,FALSE
 peru,America/Lima,America/Lima,FALSE
 philippines,Asia/Manila,Asia/Manila,FALSE
-phoenix islands,Pacific/Enderbury,Pacific/Enderbury,FALSE
+phoenix islands,Pacific/Fakaofo,Pacific/Fakaofo,FALSE
 pierre miquelon,America/Miquelon,America/Miquelon,FALSE
 pitcairn,Pacific/Pitcairn,Pacific/Pitcairn,FALSE
 "prague, central europe",Europe/Prague,Europe/Prague,FALSE
@@ -541,7 +541,7 @@ norfolk island,Pacific/Norfolk,,TRUE
 coordinated universal time+12,Pacific/Tarawa,,TRUE
 petropavlovsk-kamchatsky - old,Asia/Anadyr,,TRUE
 chatham islands,Pacific/Chatham,,TRUE
-coordinated universal time+13,Pacific/Enderbury,,TRUE
+coordinated universal time+13,Pacific/Fakaofo,,TRUE
 nuku'alofa,Pacific/Tongatapu,,TRUE
 kiritimati island,Pacific/Kiritimati,,TRUE
 "helsinki, kyiv, riga, sofia, tallinn, vilnius",Europe/Helsinki,,TRUE


### PR DESCRIPTION
Enderbury was moved to the deprecated timezone list in 2021b